### PR TITLE
Issues 26 uncaught type error

### DIFF
--- a/lib/lcov-info-view.coffee
+++ b/lib/lcov-info-view.coffee
@@ -21,7 +21,7 @@ class LcovInfoView extends View
 
     atom.commands.add 'atom-workspace', CMD_TOGGLE, => @toggle()
     atom.workspace.onDidChangeActivePaneItem (item) => @updateEditor()
-    atom.workspace.onDidAddTextEditor (ev) => @updateEditor(ev.getEditor())
+    atom.workspace.onDidAddTextEditor (ev) => @updateEditor(ev.testEditor)
 
     return
 

--- a/lib/lcov-info-view.coffee
+++ b/lib/lcov-info-view.coffee
@@ -21,7 +21,7 @@ class LcovInfoView extends View
 
     atom.commands.add 'atom-workspace', CMD_TOGGLE, => @toggle()
     atom.workspace.onDidChangeActivePaneItem (item) => @updateEditor()
-    atom.workspace.onDidAddTextEditor (ev) => @updateEditor(ev.testEditor)
+    atom.workspace.onDidAddTextEditor (ev) => @updateEditor(ev.textEditor)
 
     return
 


### PR DESCRIPTION
Hi, please accept this PR. It's fix issues #26, #29 and pehraps #30.

I use API documentation for onDidAddTextEditor.
https://atom.io/docs/api/v1.0.9/Workspace#instance-onDidAddTextEditor
`getEditor` method doesn't exist for event object, so it is undefined.

And thank you for your package.
Toff9