### PR TITLE
Fixed conflict with the "coverage" Atom package

### DIFF
--- a/keymaps/lcov-info.cson
+++ b/keymaps/lcov-info.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.atom-workspace':
+'atom-workspace':
   'ctrl-alt-c': 'lcov-info:toggle'

--- a/lib/panel-row.coffee
+++ b/lib/panel-row.coffee
@@ -47,4 +47,4 @@ class PanelRow extends HTMLElement
   openFile: (filePath) ->
     atom.workspace.open(filePath, true)
 
-module.exports = document.registerElement('coverage-table-row', prototype: PanelRow.prototype, extends: 'tr')
+module.exports = document.registerElement('lcov-info-table-row', prototype: PanelRow.prototype, extends: 'tr')

--- a/lib/panel.coffee
+++ b/lib/panel.coffee
@@ -65,4 +65,4 @@ class PanelView extends HTMLElement
     @remove() if @parentNode
     return
 
-module.exports = document.registerElement('coverage-panel-view', prototype: PanelView.prototype, extends: 'div')
+module.exports = document.registerElement('lcov-info-panel-view', prototype: PanelView.prototype, extends: 'div')


### PR DESCRIPTION
- This pull requests fixes the failure at the package activation (#32) which is caused by a conflict in the element name.
- It fixes also the non-functional keyboard shortcut.