### PR TITLE
Fix table in the bottom panel

### DIFF
--- a/lib/panel-row.coffee
+++ b/lib/panel-row.coffee
@@ -1,4 +1,4 @@
-class PanelRow extends HTMLElement
+class PanelRow extends HTMLTableRowElement
   initialize: (type, file) ->
     colTitle = @createColumn()
     colTitleIcon = document.createElement('span')

--- a/styles/lcov-info.less
+++ b/styles/lcov-info.less
@@ -6,55 +6,17 @@
   // remove padding around the table
   .panel-body { padding: 0 }
 
-
+  // style the table
   table {
     width: 100%;
-    table-layout: fixed;
-    border-collapse: collapse;
 
-    th {
-      padding: 10px;
-      &.sort-header {
-        cursor: pointer;
-
-        &:after {
-          content: "";
-          float: right;
-          margin-top: 4px;
-          border-width: 0 4px 4px;
-          border-style: solid;
-          border-color: #868686 transparent;
-          visibility: hidden;
-        }
-
-        &:hover:after, &.sort-up:after, &.sort-down:after {
-          visibility: visible;
-        }
-
-        &.sort-up:after {
-          border-bottom: none;
-          border-width: 4px 4px 0;
-        }
-      }
-    }
-    th, td {
-      padding: 10px;
-      float: left;
+    thead, tbody {
+      width: 100%;
       display: block;
-      text-align: left;
     }
-
-    td:nth-child(1), th:nth-child(1) { width: 50%; }
-    td:nth-child(2), th:nth-child(2) { width: 20%; }
-    td:nth-child(3), th:nth-child(3) { width: 10%; }
-    td:nth-child(4), th:nth-child(4) { width: 10%; }
-    td:nth-child(5), th:nth-child(5) { width: 10%; }
 
     tr {
-      background: @base-background-color;
-      border-bottom: 1px solid @tool-panel-background-color;
       width: 100%;
-
       display: block;
       &::after {
         content: " ";
@@ -64,34 +26,72 @@
       }
     }
 
-    thead {
-      tr {
-        display: block;
-        position: relative;
-      }
-    }
-    tbody {
+    th, td {
+      width: 10%;
+      &:nth-child(1) { width: 50% }
+      &:nth-child(2) { width: 20% }
       display: block;
-      overflow: auto;
-      width: 100%;
-      height: 150px;
-      td {
-        padding: 7px 10px;
+      float: left;
+    }
+
+    thead {
+      padding: 0;
+
+      th {
+        padding: 10px;
+
+        // sortable
+        &.sort-header {
+          cursor: pointer;
+
+          &:after {
+            content: "";
+            float: right;
+            margin-top: 4px;
+            border-width: 0 4px 4px;
+            border-style: solid;
+            border-color: #868686 transparent;
+            visibility: hidden;
+          }
+
+          &:hover:after, &.sort-up:after, &.sort-down:after {
+            visibility: visible;
+          }
+
+          &.sort-up:after {
+            border-bottom: none;
+            border-width: 4px 4px 0;
+          }
+        }
       }
     }
 
+    tbody {
+      max-height: 160px;
+      overflow-x: hidden;
+      overflow-y: auto;
 
-    progress {
-      width: 100%;
+      tr {
+        background: @base-background-color;
+        border-bottom: 1px solid @tool-panel-background-color;
 
-      &.green::-webkit-progress-value { background-color: @lcov-bar-green; border: 1px solid @lcov-bdr-green }
-      &.red::-webkit-progress-value { background-color: @lcov-bar-red; border: 1px solid @lcov-bdr-red }
-      &.orange::-webkit-progress-value { background-color: @lcov-bar-orange; border: 1px solid @lcov-bdr-orange }
+        td {
+          padding: 7px 10px;
+
+          &:first-child > span { cursor: pointer }
+        }
+      }
     }
   }
 
+  // progress bar styles
+  progress {
+    width: 100%;
 
-
+    &.green::-webkit-progress-value { background-color: @lcov-bar-green; border: 1px solid @lcov-bdr-green }
+    &.red::-webkit-progress-value { background-color: @lcov-bar-red; border: 1px solid @lcov-bdr-red }
+    &.orange::-webkit-progress-value { background-color: @lcov-bar-orange; border: 1px solid @lcov-bdr-orange }
+  }
 }
 
 .lcov-info-status {

--- a/styles/lcov-info.less
+++ b/styles/lcov-info.less
@@ -27,11 +27,11 @@
     }
 
     th, td {
+      display: block;
+      float: left;
       width: 10%;
       &:nth-child(1) { width: 50% }
       &:nth-child(2) { width: 20% }
-      display: block;
-      float: left;
     }
 
     thead {

--- a/styles/lcov-info.less
+++ b/styles/lcov-info.less
@@ -6,18 +6,56 @@
   // remove padding around the table
   .panel-body { padding: 0 }
 
-  // style the table
+
   table {
     width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
 
-    thead, tbody {
-      width: 100%;
+    th {
+      padding: 10px;
+      &.sort-header {
+        cursor: pointer;
+
+        &:after {
+          content: "";
+          float: right;
+          margin-top: 4px;
+          border-width: 0 4px 4px;
+          border-style: solid;
+          border-color: #868686 transparent;
+          visibility: hidden;
+        }
+
+        &:hover:after, &.sort-up:after, &.sort-down:after {
+          visibility: visible;
+        }
+
+        &.sort-up:after {
+          border-bottom: none;
+          border-width: 4px 4px 0;
+        }
+      }
+    }
+    th, td {
+      padding: 10px;
+      float: left;
       display: block;
+      text-align: left;
     }
 
+    td:nth-child(1), th:nth-child(1) { width: 50%; }
+    td:nth-child(2), th:nth-child(2) { width: 20%; }
+    td:nth-child(3), th:nth-child(3) { width: 10%; }
+    td:nth-child(4), th:nth-child(4) { width: 10%; }
+    td:nth-child(5), th:nth-child(5) { width: 10%; }
+
     tr {
+      background: @base-background-color;
+      border-bottom: 1px solid @tool-panel-background-color;
       width: 100%;
 
+      display: block;
       &::after {
         content: " ";
         display: block;
@@ -26,76 +64,39 @@
       }
     }
 
-    th, td {
-      width: 10%;
-
-      &:nth-child(1) { width: 50% }
-      &:nth-child(2) { width: 20% }
-    }
-
     thead {
-      padding: 0;
-
-      th {
-        padding: 10px;
-
-        // sortable
-        &.sort-header {
-          cursor: pointer;
-
-          &:after {
-            content: "";
-            float: right;
-            margin-top: 4px;
-            border-width: 0 4px 4px;
-            border-style: solid;
-            border-color: #868686 transparent;
-            visibility: hidden;
-          }
-
-          &:hover:after, &.sort-up:after, &.sort-down:after {
-            visibility: visible;
-          }
-
-          &.sort-up:after {
-            border-bottom: none;
-            border-width: 4px 4px 0;
-          }
-        }
-      }
-    }
-
-    tbody {
-      max-height: 160px;
-      overflow-x: hidden;
-      overflow-y: auto;
-
       tr {
-        background: @base-background-color;
-        border-bottom: 1px solid @tool-panel-background-color;
-
-        td {
-          padding: 7px 10px;
-
-          &:first-child > span { cursor: pointer }
-        }
+        display: block;
+        position: relative;
       }
+    }
+    tbody {
+      display: block;
+      overflow: auto;
+      width: 100%;
+      height: 150px;
+      td {
+        padding: 7px 10px;
+      }
+    }
+
+
+    progress {
+      width: 100%;
+
+      &.green::-webkit-progress-value { background-color: @lcov-bar-green; border: 1px solid @lcov-bdr-green }
+      &.red::-webkit-progress-value { background-color: @lcov-bar-red; border: 1px solid @lcov-bdr-red }
+      &.orange::-webkit-progress-value { background-color: @lcov-bar-orange; border: 1px solid @lcov-bdr-orange }
     }
   }
 
-  // progress bar styles
-  progress {
-    width: 100%;
 
-    &.green::-webkit-progress-value { background-color: @lcov-bar-green; border: 1px solid @lcov-bdr-green }
-    &.red::-webkit-progress-value { background-color: @lcov-bar-red; border: 1px solid @lcov-bdr-red }
-    &.orange::-webkit-progress-value { background-color: @lcov-bar-orange; border: 1px solid @lcov-bdr-orange }
-  }
+
 }
 
 .lcov-info-status {
   cursor: pointer;
-  
+
   &.red { color: @background-color-error }
   &.orange { color: @background-color-warning }
   &.green { color: @background-color-success }


### PR DESCRIPTION
Fixes the sorting issue mentioned in #31, #36, #40 and #45. The cause was the `PanelRow` class extending the wrong element, meaning the `.cells` property did not exist. Which threw a error, stopped sorting from working.

Also fix the styles of the table mentioned in #42.
