### PR TITLE
Fix gutter in Seti syntax

### DIFF
--- a/styles/lcov-info.atom-text-editor.less
+++ b/styles/lcov-info.atom-text-editor.less
@@ -2,6 +2,7 @@
 @import "lcov-info-vars";
 
 .atom-text-editor, :host {
+  .gutter .line-number,
   .line-number {
     &.lcov-info-no-coverage {
       &::after {


### PR DESCRIPTION
In Seti syntax, gutter dots were displayed grey. Adding `.gutter` before `.line-number` fixed the issue.